### PR TITLE
Cleanup2

### DIFF
--- a/DeltGeometriFelleskomponent.Api/Controllers/TopologyController.cs
+++ b/DeltGeometriFelleskomponent.Api/Controllers/TopologyController.cs
@@ -96,5 +96,12 @@ namespace DeltGeometriFelleskomponent.Api.Controllers
         [HttpPost(template:"resolveReferences")]
         public TopologyResponse Change([FromBody] ToplogyRequest request)
             => _topologyImplementation.ResolveReferences(request);
+        
+        /// <summary>
+        /// Create a polygon feature given a set of line features and an optional centroid
+        /// </summary>
+        [HttpPost(template: "polygonFromLines")]
+        public TopologyResponse CreatePolygonFromLies([FromBody] CreatePolygonFromLinesRequest request)
+            => _topologyImplementation.CreatePolygonFromLines(request);
     }
 }

--- a/DeltGeometriFelleskomponent.Models/CreatePolygonFromLinesRequest.cs
+++ b/DeltGeometriFelleskomponent.Models/CreatePolygonFromLinesRequest.cs
@@ -1,0 +1,9 @@
+﻿using NetTopologySuite.Geometries;
+
+namespace DeltGeometriFelleskomponent.Models;
+
+public class CreatePolygonFromLinesRequest
+{
+    public List<NgisFeature> Features { get; set; } = new();
+    public Point? Centroid { get; set; }
+}

--- a/DeltGeometriFelleskomponent.TopologyImplementation/ITopologyImplementation.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/ITopologyImplementation.cs
@@ -5,4 +5,6 @@ namespace DeltGeometriFelleskomponent.TopologyImplementation;
 public interface ITopologyImplementation
 {
     TopologyResponse ResolveReferences(ToplogyRequest request);
+
+    TopologyResponse CreatePolygonFromLines(CreatePolygonFromLinesRequest request);
 }

--- a/DeltGeometriFelleskomponent.TopologyImplementation/PolygonCreator.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/PolygonCreator.cs
@@ -1,5 +1,6 @@
 ﻿using DeltGeometriFelleskomponent.Models;
 using NetTopologySuite.Geometries;
+using NetTopologySuite.Operation.Polygonize;
 
 namespace DeltGeometriFelleskomponent.TopologyImplementation;
 
@@ -14,6 +15,121 @@ public class PolygonCreator
         {
             AffectedFeatures = request.AffectedFeatures.Concat(new List<NgisFeature>(){request.Feature, exteriorLine}).Concat(interiorLines).ToList(),
             IsValid = true
+        };
+    }
+
+    public TopologyResponse CreatePolygonFromLines(string type, List<NgisFeature> lineFeatures, Point? centroid)
+    {
+        // use  Polygonizer polygonizer for all operations
+        var isValid = true;
+        Polygon? polygon = null;
+        // Now supports  multiple linestrings and order
+        Polygonizer polygonizer = new Polygonizer(extractOnlyPolygonal: true);
+
+        foreach (var lineFeature in lineFeatures)
+        {
+            polygonizer.Add(lineFeature.Geometry);
+        }
+
+        if (polygonizer.GetPolygons().Count > 0)
+        {
+            polygon = (Polygon)polygonizer.GetPolygons().First();
+            isValid = polygon.IsValid;
+
+            if (!polygon.Shell.IsCCW)
+            {
+                // TODO: Check if polygon.Reverse is enough
+                Console.WriteLine("Polygon is not CCW");
+                polygon = (Polygon)polygon.Reverse(); // reverse polygon
+            }
+
+            if (centroid != null)
+            {
+                var inside = polygon.Contains(centroid);
+                Console.WriteLine("Point is inside polygon:{0}", inside);
+                isValid = inside;
+            }
+        }
+        else
+        {
+            isValid = false;
+        }
+
+        var cutEdges = polygonizer.GetCutEdges();
+        var dangels = polygonizer.GetDangles();
+
+        if (cutEdges.Count > 0) Console.WriteLine("cutEdges.Count:{0}", cutEdges.Count);
+        if (dangels.Count > 0) Console.WriteLine("dangels.Count:{0}", dangels.Count);
+
+
+        var lokalId = Guid.NewGuid().ToString();
+
+
+        var polygonFeature = NgisFeatureHelper.CreateFeature(polygon, lokalId);
+
+        if (polygon != null)
+        {
+
+
+            var exterior = polygon.ExteriorRing;
+            var interiors = polygon.InteriorRings;
+            var referencesExterior = new List<NgisFeature>();
+            List<List<NgisFeature>>? referencesInteriors = null;
+
+            foreach (var feature in lineFeatures)
+            {
+                if (feature.Geometry.CoveredBy(exterior))
+                {
+                    referencesExterior.Add(feature);
+                }
+            }
+
+            if (interiors != null && interiors.Length > 0)
+            {
+                foreach (var hole in interiors)
+                {
+                    List<NgisFeature>? referencesOnehole = null;
+                    foreach (var feature in lineFeatures)
+                    {
+                        if (feature.Geometry.CoveredBy(hole))
+                        {
+                            //referencesInteriors ??= new List<List<NgisFeature>>();
+                            if (referencesInteriors == null)
+                            {
+                                referencesInteriors = new List<List<NgisFeature>>();
+                            }
+
+                            referencesOnehole ??= new List<NgisFeature>();
+                            //if (referencesOnehole == null)
+                            //{
+                            //    referencesOnehole = new List<NgisFeature>();
+                            //}
+
+
+                            referencesOnehole.Add(feature);
+                        }
+                    }
+
+                    if (referencesOnehole != null) referencesInteriors?.Add(referencesOnehole);
+                }
+            }
+
+            NgisFeatureHelper.SetReferences(polygonFeature, referencesExterior, referencesInteriors);
+        }
+
+        else
+        {
+            NgisFeatureHelper.SetReferences(polygonFeature, lineFeatures, null);
+        }
+        NgisFeatureHelper.SetOperation(polygonFeature, Operation.Create);
+
+        lineFeatures.ForEach(a => NgisFeatureHelper.SetReferences(a, new List<string>() { lokalId }, null));
+
+        //set type to type
+        return new TopologyResponse()
+        {
+            AffectedFeatures = new List<NgisFeature>(){ polygonFeature },
+            IsValid = isValid
         };
     }
 

--- a/DeltGeometriFelleskomponent.TopologyImplementation/PolygonCreator.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/PolygonCreator.cs
@@ -18,7 +18,7 @@ public class PolygonCreator
         };
     }
 
-    public TopologyResponse CreatePolygonFromLines(string type, List<NgisFeature> lineFeatures, Point? centroid)
+    public TopologyResponse CreatePolygonFromLines(List<NgisFeature> lineFeatures, Point? centroid)
     {
         // use  Polygonizer polygonizer for all operations
         var isValid = true;

--- a/DeltGeometriFelleskomponent.TopologyImplementation/TopologyImplementation.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/TopologyImplementation.cs
@@ -30,7 +30,7 @@ public class TopologyImplementation : ITopologyImplementation
             null => new TopologyResponse()
 
         };
-
+    
     private TopologyResponse HandlePolygon(ToplogyRequest request)
     {
         var result = new TopologyResponse()
@@ -40,55 +40,10 @@ public class TopologyImplementation : ITopologyImplementation
 
         if (request.Feature.Geometry.IsEmpty)
         {
-
             // Polygonet er tomt, altså ønsker brukeren å lage et nytt polygon basert på grenselinjer
-
-            if (request.Feature.Geometry_Properties.Exterior == null) return new TopologyResponse();
-            if (request.AffectedFeatures == null) return new TopologyResponse();
-
-            var affected = request.AffectedFeatures.ToDictionary(NgisFeatureHelper.GetLokalId, a => a);
-
-            var referredFeatures = new List<NgisFeature>();
-            foreach (var referred in request.Feature.Geometry_Properties.Exterior)
-            {
-                if (affected.TryGetValue(referred, out var referredFeature))
-                {
-                    referredFeatures.Add(referredFeature);
-                }
-                else
-                {
-                    throw new Exception("Referred feature not present in AffectedFeatures");
-                }
-            }
-
-            // If interiors as input. Note that if interiors is not specified, we'll find the holes either way
-            if (request.Feature.Geometry_Properties.Interiors != null && request.Feature.Geometry_Properties.Interiors.Count > 0)
-            {
-                foreach (var hole in request.Feature.Geometry_Properties.Interiors)
-                {
-
-                    foreach (var referred in hole)
-                    {
-                        if (affected.TryGetValue(referred, out var referredFeature))
-                        {
-                            referredFeatures.Add(referredFeature);
-                        }
-                        else
-                        {
-                            throw new Exception("Referred feature not present in AffectedFeatures");
-                        }
-                    }
-                }
-            }
-
-
-            //request.Feature.Centroid
-            var resultPolygon = CreatePolygonFromLines(request.Feature.Type, referredFeatures, null, out var isValid);
-
-            result.AffectedFeatures.Add(resultPolygon);
-            result.IsValid = isValid; // true;
-
-            return result;
+            if (request.Feature.Geometry_Properties?.Exterior == null) return new TopologyResponse();
+            var referredFeatures = GetReferredFeatures(request.Feature, result.AffectedFeatures);
+            return _polygonCreator.CreatePolygonFromLines(request.Feature.Type, referredFeatures, null);
         }
         return _polygonCreator.CreatePolygonFromGeometry(request);
     }
@@ -104,114 +59,29 @@ public class TopologyImplementation : ITopologyImplementation
     }
 
 
-    private NgisFeature CreatePolygonFromLines(string type, List<NgisFeature> lineFeatures, Point? centroid, out bool isValid)
+    private static List<NgisFeature> GetReferredFeatures(NgisFeature feature, IEnumerable<NgisFeature> affectedFeatures)
     {
-        // use  Polygonizer polygonizer for all operations
-
-        Polygon? polygon = null;
-        // Now supports  multiple linestrings and order
-        Polygonizer polygonizer = new Polygonizer(extractOnlyPolygonal: true);
-        
-        foreach (var lineFeature in lineFeatures)
+        var affected = affectedFeatures.ToDictionary(NgisFeatureHelper.GetLokalId, a => a);
+        var referredFeatures = new List<NgisFeature>();
+        if (feature.Geometry_Properties == null)
         {
-            polygonizer.Add(lineFeature.Geometry);
+            throw new Exception("Missing Geometry_Properties on feature");
         }
 
-        if (polygonizer.GetPolygons().Count > 0)
+        var holes = feature.Geometry_Properties?.Interiors?.SelectMany(i => i);
+
+        foreach (var featureId in feature.Geometry_Properties!.Exterior.Concat(holes ?? new List<string>()))
         {
-            polygon = (Polygon)polygonizer.GetPolygons().First();
-            isValid = polygon.IsValid;
-
-            if (!polygon.Shell.IsCCW)
+            if (affected.TryGetValue(featureId, out var referredFeature))
             {
-                // TODO: Check if polygon.Reverse is enough
-                Console.WriteLine("Polygon is not CCW");
-                polygon = (Polygon)polygon.Reverse(); // reverse polygon
+                referredFeatures.Add(referredFeature);
             }
-
-            if (centroid != null)
+            else
             {
-                var inside = polygon.Contains(centroid);
-                Console.WriteLine("Point is inside polygon:{0}", inside);
-                isValid = inside;
+                throw new Exception("Referred feature not present in AffectedFeatures");
             }
         }
-        else
-        {
-            isValid = false;
-        }
 
-        var cutEdges = polygonizer.GetCutEdges();
-        var dangels = polygonizer.GetDangles();
-
-        if (cutEdges.Count > 0) Console.WriteLine("cutEdges.Count:{0}", cutEdges.Count);
-        if (dangels.Count > 0) Console.WriteLine("dangels.Count:{0}", dangels.Count);
-
-
-        var lokalId = Guid.NewGuid().ToString();
-
-
-        var polygonFeature = NgisFeatureHelper.CreateFeature(polygon, lokalId);
-
-        if (polygon != null)
-        {
-
-
-            var exterior = polygon.ExteriorRing;
-            var interiors = polygon.InteriorRings;
-            var referencesExterior = new List<NgisFeature>();
-            List<List<NgisFeature>>? referencesInteriors = null;
-
-            foreach (var feature in lineFeatures)
-            {
-                if (feature.Geometry.CoveredBy(exterior))
-                {
-                    referencesExterior.Add(feature);
-                }
-            }
-
-            if (interiors != null && interiors.Length > 0)
-            {
-                foreach (var hole in interiors)
-                {
-                    List<NgisFeature>? referencesOnehole = null;
-                    foreach (var feature in lineFeatures)
-                    {
-                        if (feature.Geometry.CoveredBy(hole))
-                        {
-                            //referencesInteriors ??= new List<List<NgisFeature>>();
-                            if (referencesInteriors == null)
-                            {
-                                referencesInteriors = new List<List<NgisFeature>>();
-                            }
-
-                            referencesOnehole ??= new List<NgisFeature>();
-                            //if (referencesOnehole == null)
-                            //{
-                            //    referencesOnehole = new List<NgisFeature>();
-                            //}
-
-
-                            referencesOnehole.Add( feature);
-                        }
-                    }
-
-                    if (referencesOnehole != null) referencesInteriors?.Add(referencesOnehole);
-                }
-            }
-
-            NgisFeatureHelper.SetReferences(polygonFeature, referencesExterior, referencesInteriors);
-        }
-
-        else
-        {
-            NgisFeatureHelper.SetReferences(polygonFeature, lineFeatures, null);
-        }
-        NgisFeatureHelper.SetOperation(polygonFeature, Operation.Create);
-
-        lineFeatures.ForEach(a => NgisFeatureHelper.SetReferences(a, new List<string>() { lokalId }, null));
-
-        //set type to type
-        return polygonFeature;
+        return referredFeatures;
     }
 }

--- a/DeltGeometriFelleskomponent.TopologyImplementation/TopologyImplementation.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/TopologyImplementation.cs
@@ -214,44 +214,4 @@ public class TopologyImplementation : ITopologyImplementation
         //set type to type
         return polygonFeature;
     }
-
-    // TODO: Alternativ for å håndtere hull ?
-    //public TopologyResponse CreatePolygonFromLines(List<NgisFeature> lineFeatures, Point? centroid)
-    //{
-    //    //if (a.Any((geom, id) => geom.))
-
-    //    //1. hent ut geometrier
-    //    //2. legg id på geometri (userData)
-    //    //3. lag polygon
-
-    //    var featureReferences = lineFeatures.Select(f => (f.Geometry, NgisFeatureHelper.GetLokalId(f)));
-
-    //    foreach (var feat in lineFeatures)
-    //    {
-    //        //feat.Geometry
-    //    }
-
-    //    foreach (var feature in featureReferences)
-    //    {
-    //        //feature.Geometry.UserData = new 
-    //    }
-
-    //    //lage feature med polygonGEometry og exterior og interiors
-
-    //    return null;
-    //}
-
-
-
-
-    //private IList<IPoint> Contains(IGeometry geom, IEnumerable<IPoint> points)
-    //{
-    //    var prepGeom = new NetTopologySuite.Geometries.Prepared.PreparedGeometryFactory().Prepare(geom);
-    //    var res = new List<IPoint>();
-    //    foreach (var point in points)
-    //    {
-    //        if (prepGeom.Contains(point)) res.Add(point);
-    //    }
-    //    return res;
-    //}
 }

--- a/DeltGeometriFelleskomponent.TopologyImplementation/TopologyImplementation.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/TopologyImplementation.cs
@@ -44,7 +44,9 @@ public class TopologyImplementation : ITopologyImplementation
             // Polygonet er tomt, altså ønsker brukeren å lage et nytt polygon basert på grenselinjer
             if (request.Feature.Geometry_Properties?.Exterior == null) return new TopologyResponse();
             var referredFeatures = GetReferredFeatures(request.Feature, result.AffectedFeatures);
-            return _polygonCreator.CreatePolygonFromLines(referredFeatures, null);
+            var res = _polygonCreator.CreatePolygonFromLines(referredFeatures, null);
+            res.AffectedFeatures = result.AffectedFeatures.Concat(res.AffectedFeatures).ToList();
+            return res;
         }
         return _polygonCreator.CreatePolygonFromGeometry(request);
     }

--- a/DeltGeometriFelleskomponent.TopologyImplementation/TopologyImplementation.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/TopologyImplementation.cs
@@ -1,7 +1,5 @@
-﻿using System.Diagnostics;
-using DeltGeometriFelleskomponent.Models;
+﻿using DeltGeometriFelleskomponent.Models;
 using NetTopologySuite.Geometries;
-using NetTopologySuite.Operation.Polygonize;
 
 namespace DeltGeometriFelleskomponent.TopologyImplementation;
 
@@ -17,6 +15,9 @@ public class TopologyImplementation : ITopologyImplementation
             Operation.Replace => HandleUpdate(request),
             null => throw new ArgumentException("")
         };
+
+    public TopologyResponse CreatePolygonFromLines(CreatePolygonFromLinesRequest request)
+        => _polygonCreator.CreatePolygonFromLines(request.Features, request.Centroid);
 
     private TopologyResponse HandleCreate(ToplogyRequest request)
         => request.Feature.Geometry switch
@@ -43,7 +44,7 @@ public class TopologyImplementation : ITopologyImplementation
             // Polygonet er tomt, altså ønsker brukeren å lage et nytt polygon basert på grenselinjer
             if (request.Feature.Geometry_Properties?.Exterior == null) return new TopologyResponse();
             var referredFeatures = GetReferredFeatures(request.Feature, result.AffectedFeatures);
-            return _polygonCreator.CreatePolygonFromLines(request.Feature.Type, referredFeatures, null);
+            return _polygonCreator.CreatePolygonFromLines(referredFeatures, null);
         }
         return _polygonCreator.CreatePolygonFromGeometry(request);
     }


### PR DESCRIPTION
1. den nye CreatePolygonFromLines burde være public?
2. CreatePolygonFromLines burde legges til i ITopologyImplementation og eksponeres ut via apiet. 
3. out bool isValid på CreatePolygonFromLines burde heller legges på en response-klasse fra metoden
4. trenger vi alt jazzet i HandlePolygon nå som vi har CreatePolygonFromLines ?
5. CreatePolygonFromLines burde kanskje flyttes til PolygonCreator
6. vi har to utkommenterte metoder i TopologyImplementation, kan vi slette dette? OCDen min får vondt