### PR TITLE
- CreatePolygonFromLines now returns NgisFeature FeatureReferences fo…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -360,3 +360,4 @@ MigrationBackup/
 .ionide/
 
 
+/DeltGeometriFelleskomponent.Tests/TopologyImplementationTest - Copy.cs

--- a/DeltGeometriFelleskomponent.Tests/DeltGeometriFelleskomponent.Tests.csproj
+++ b/DeltGeometriFelleskomponent.Tests/DeltGeometriFelleskomponent.Tests.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="TopologyImplementationTest - Copy.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NetTopologySuite" Version="2.4.0" />
     <PackageReference Include="NetTopologySuite.IO.GeoJSON4STJ" Version="2.1.1" />

--- a/DeltGeometriFelleskomponent.TopologyImplementation/ITopologyImplementation.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/ITopologyImplementation.cs
@@ -7,4 +7,6 @@ public interface ITopologyImplementation
     TopologyResponse ResolveReferences(ToplogyRequest request);
 
     TopologyResponse CreatePolygonFromLines(CreatePolygonFromLinesRequest request);
+
+    //TopologyResponse CreatePolygonFromGeometry(ToplogyRequest request);
 }

--- a/DeltGeometriFelleskomponent.TopologyImplementation/PolygonCreator.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/PolygonCreator.cs
@@ -1,6 +1,7 @@
 ﻿using DeltGeometriFelleskomponent.Models;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.Operation.Polygonize;
+using System.Linq;
 
 namespace DeltGeometriFelleskomponent.TopologyImplementation;
 
@@ -9,11 +10,11 @@ public class PolygonCreator
     public TopologyResponse CreatePolygonFromGeometry(ToplogyRequest request)
     {
         NgisFeatureHelper.EnsureLocalId(request.Feature);
-        var exteriorLine = CreateExteriorLineForPolyon( request.Feature);
+        var exteriorLine = CreateExteriorLineForPolyon(request.Feature);
         var interiorLines = CreateInteriorLinesForPolyon(request.Feature);
         return new TopologyResponse()
         {
-            AffectedFeatures = request.AffectedFeatures.Concat(new List<NgisFeature>(){request.Feature, exteriorLine}).Concat(interiorLines).ToList(),
+            AffectedFeatures = request.AffectedFeatures.Concat(new List<NgisFeature>() { request.Feature, exteriorLine }).Concat(interiorLines).ToList(),
             IsValid = true
         };
     }
@@ -31,7 +32,7 @@ public class PolygonCreator
                 IsValid = false
             };
         }
-   
+
         var polygon = (Polygon)polygonizer.GetPolygons().First();
         var isValid = polygon.IsValid;
 
@@ -48,7 +49,7 @@ public class PolygonCreator
             Console.WriteLine("Point is inside polygon:{0}", inside);
             isValid = inside;
         }
-        
+
 
         var cutEdges = polygonizer.GetCutEdges();
         var dangels = polygonizer.GetDangles();
@@ -62,14 +63,19 @@ public class PolygonCreator
 
         var polygonFeature = NgisFeatureHelper.CreateFeature(polygon, lokalId);
 
+
+        IEnumerable<NgisFeature>? referencesExterior = null;
+        IEnumerable<List<NgisFeature>>? referencesInteriors = null;
+
+
         if (polygon != null)
         {
             var exterior = polygon.ExteriorRing;
             var interiors = polygon.InteriorRings;
-            var referencesExterior = lineFeatures.Where(feature => feature.Geometry.CoveredBy(exterior));
-            var referencesInteriors = interiors.Select(hole =>
-                lineFeatures.Where(feature => feature.Geometry.CoveredBy(hole)).ToList()).Where(hole => hole.Count >0);
-            
+            referencesExterior = lineFeatures.Where(feature => feature.Geometry.CoveredBy(exterior));
+            referencesInteriors = interiors.Select(hole =>
+                lineFeatures.Where(feature => feature.Geometry.CoveredBy(hole)).ToList()).Where(hole => hole.Count > 0);
+
             NgisFeatureHelper.SetReferences(polygonFeature, referencesExterior, referencesInteriors);
         }
 
@@ -81,12 +87,18 @@ public class PolygonCreator
 
         lineFeatures.ForEach(a => NgisFeatureHelper.SetReferences(a, new List<string>() { lokalId }, null));
 
-        //set type to type
+        //CreatePolygonFromLines now return NgisFeature FeatureReferences for lines in addition to the new polygon
+        var affectedExteriors = referencesExterior.ToList().ToList();
+        var affectedInteriors = referencesInteriors.SelectMany(listNgisInterior => listNgisInterior).ToList();
+        var affectedPolygon = new List<NgisFeature>() { polygonFeature };
+        var affected = affectedExteriors.Concat(affectedInteriors).Concat(affectedPolygon);
+        
         return new TopologyResponse()
         {
-            AffectedFeatures = new List<NgisFeature>(){ polygonFeature },
+            AffectedFeatures = affected.ToList(),
             IsValid = isValid
         };
+
     }
 
     private static NgisFeature CreateExteriorLineForPolyon(NgisFeature polygonFeature)
@@ -101,9 +113,10 @@ public class PolygonCreator
     private static IEnumerable<NgisFeature> CreateInteriorLinesForPolyon(NgisFeature polygonFeature)
     {
         var interiorFeatures = ((Polygon)polygonFeature.Geometry).InteriorRings.Select(CreateInteriorFeature).ToList();
-        if (interiorFeatures.Count > 0) {
+        if (interiorFeatures.Count > 0)
+        {
             //TODO: Handle winding?
-            NgisFeatureHelper.SetInterior(polygonFeature, interiorFeatures.Select(f => new List<NgisFeature>(){f}));
+            NgisFeatureHelper.SetInterior(polygonFeature, interiorFeatures.Select(f => new List<NgisFeature>() { f }));
         }
         return interiorFeatures;
     }

--- a/DeltGeometriFelleskomponent.TopologyImplementation/TopologyImplementation.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/TopologyImplementation.cs
@@ -44,8 +44,9 @@ public class TopologyImplementation : ITopologyImplementation
             // Polygonet er tomt, altså ønsker brukeren å lage et nytt polygon basert på grenselinjer
             if (request.Feature.Geometry_Properties?.Exterior == null) return new TopologyResponse();
             var referredFeatures = GetReferredFeatures(request.Feature, result.AffectedFeatures);
+            // CreatePolygonFromLines now return NgisFeature FeatureReferences for lines
             var res = _polygonCreator.CreatePolygonFromLines(referredFeatures, null);
-            res.AffectedFeatures = result.AffectedFeatures.Concat(res.AffectedFeatures).ToList();
+            //res.AffectedFeatures = result.AffectedFeatures.Concat(res.AffectedFeatures).ToList();
             return res;
         }
         return _polygonCreator.CreatePolygonFromGeometry(request);


### PR DESCRIPTION
…r lines.

- Reimplemented InsideCheck for centro if input.
- _topologyImplementation.CreatePolygonFromLines replaces _topologyImplementation.ResolveReferences in unit test TopologyImplementationTest
- Test add a line that is not part of the polygon, that will work now for CreatePolygonFromLines