### PR TITLE
Funksjonalitet for å sende inn editert polygon

### DIFF
--- a/DeltGeometriFelleskomponent.Api/Controllers/TopologyController.cs
+++ b/DeltGeometriFelleskomponent.Api/Controllers/TopologyController.cs
@@ -302,5 +302,10 @@ namespace DeltGeometriFelleskomponent.Api.Controllers
         public TopologyResponse EditLine([FromBody] EditLineRequest request)
             => _topologyImplementation.EditLine(request);
 
+
+        [HttpPost(template: "editPolygon")]
+        public TopologyResponse EditPolygon([FromBody] EditPolygonRequest request)
+            => _topologyImplementation.EditPolygon(request);
+
     }
 }

--- a/DeltGeometriFelleskomponent.Models/EditPolygonRequest.cs
+++ b/DeltGeometriFelleskomponent.Models/EditPolygonRequest.cs
@@ -1,0 +1,11 @@
+﻿using NetTopologySuite.Geometries;
+
+namespace DeltGeometriFelleskomponent.Models;
+
+public class EditPolygonRequest
+{
+    public List<NgisFeature>? AffectedFeatures { get; set; }
+    public NgisFeature Feature { get; set; }
+    public Polygon EditedGeometry { get; set; }
+}
+

--- a/DeltGeometriFelleskomponent.Models/NgisFeatureHelper.cs
+++ b/DeltGeometriFelleskomponent.Models/NgisFeatureHelper.cs
@@ -140,7 +140,13 @@ public static class NgisFeatureHelper
         {
             props.Add("identifikasjon",new AttributesTable());
         }
-        ((IAttributesTable)props["identifikasjon"]).Add("lokalId", lokalId);
+        var id = ((AttributesTable)props["identifikasjon"]);
+        if (!id.Exists("lokalId")) { 
+            id.Add("lokalId", lokalId);
+        } else
+        {
+            id["lokalId"] = lokalId;   
+        }
 
         feature.Properties = props;
         

--- a/DeltGeometriFelleskomponent.Tests/LineEditorTest.cs
+++ b/DeltGeometriFelleskomponent.Tests/LineEditorTest.cs
@@ -8,7 +8,7 @@ using Xunit.Abstractions;
 
 namespace DeltGeometriFelleskomponent.Tests;
 
-public class GeometryEditTest : TestBase
+public class LineEditorTest : TestBase
 {
     private readonly NgisFeature LineFeature = new()
     {
@@ -86,7 +86,7 @@ public class GeometryEditTest : TestBase
 
     private readonly ITestOutputHelper output;
 
-    public GeometryEditTest(ITestOutputHelper output)
+    public LineEditorTest(ITestOutputHelper output)
     {
         // Capturing output in unit tests
         this.output = output;
@@ -95,7 +95,7 @@ public class GeometryEditTest : TestBase
     [Fact]
     public void DeletesNodeOnLine()
     {
-        var res = GeometryEdit.EditObject(new EditLineRequest()
+        var res = LineEditor.EditObject(new EditLineRequest()
         {
             AffectedFeatures = new List<NgisFeature>(),
             Feature = NgisFeatureHelper.Copy(LineFeature),
@@ -114,7 +114,7 @@ public class GeometryEditTest : TestBase
     [Fact]
     public void InsertsNodeOnLineIndex0()
     {
-        var res = GeometryEdit.EditObject(new EditLineRequest()
+        var res = LineEditor.EditObject(new EditLineRequest()
         {
             AffectedFeatures = new List<NgisFeature>(),
             Feature = NgisFeatureHelper.Copy(LineFeature),
@@ -134,7 +134,7 @@ public class GeometryEditTest : TestBase
     [Fact]
     public void InsertsNodeOnLineIndex1()
     {
-        var res = GeometryEdit.EditObject(new EditLineRequest()
+        var res = LineEditor.EditObject(new EditLineRequest()
         {
             AffectedFeatures = new List<NgisFeature>(),
             Feature = NgisFeatureHelper.Copy(LineFeature),
@@ -155,7 +155,7 @@ public class GeometryEditTest : TestBase
     [Fact]
     public void InsertsNodeOnLineIndex2()
     {
-        var res = GeometryEdit.EditObject(new EditLineRequest()
+        var res = LineEditor.EditObject(new EditLineRequest()
         {
             AffectedFeatures = new List<NgisFeature>(),
             Feature = NgisFeatureHelper.Copy(LineFeature),
@@ -177,7 +177,7 @@ public class GeometryEditTest : TestBase
     [Fact]
     public void InsertsNodeOnLineIndex3()
     {
-        var res = GeometryEdit.EditObject(new EditLineRequest()
+        var res = LineEditor.EditObject(new EditLineRequest()
         {
             AffectedFeatures = new List<NgisFeature>(),
             Feature = NgisFeatureHelper.Copy(LineFeature),
@@ -202,7 +202,7 @@ public class GeometryEditTest : TestBase
     [Fact]
     public void DeletesNodeOnLineWithWithNewFeature()
     {
-        var res = GeometryEdit.EditObject(new EditLineRequest()
+        var res = LineEditor.EditObject(new EditLineRequest()
         {
             AffectedFeatures = new List<NgisFeature>(),
             Feature = NgisFeatureHelper.Copy(LineFeature),
@@ -221,7 +221,7 @@ public class GeometryEditTest : TestBase
     [Fact]
     public void InsertsNodeOnLineIndex0WithNewFeature()
     {
-        var res = GeometryEdit.EditObject(new EditLineRequest()
+        var res = LineEditor.EditObject(new EditLineRequest()
         {
             AffectedFeatures = new List<NgisFeature>(),
             Feature = NgisFeatureHelper.Copy(LineFeature),
@@ -240,7 +240,7 @@ public class GeometryEditTest : TestBase
     [Fact]
     public void InsertsNodeOnLineIndex1WithNewFeature()
     {
-        var res = GeometryEdit.EditObject(new EditLineRequest()
+        var res = LineEditor.EditObject(new EditLineRequest()
         {
             AffectedFeatures = new List<NgisFeature>(),
             Feature = NgisFeatureHelper.Copy(LineFeature),
@@ -261,7 +261,7 @@ public class GeometryEditTest : TestBase
     [Fact]
     public void InsertsNodeOnLineIndex2WithOldFeature()
     {
-        var res = GeometryEdit.EditObject(new EditLineRequest()
+        var res = LineEditor.EditObject(new EditLineRequest()
         {
             AffectedFeatures = new List<NgisFeature>(),
             Feature = NgisFeatureHelper.Copy(LineFeature),
@@ -283,7 +283,7 @@ public class GeometryEditTest : TestBase
     [Fact]
     public void InsertsNodeOnLineIndex3WithOldFeature()
     {
-        var res = GeometryEdit.EditObject(new EditLineRequest()
+        var res = LineEditor.EditObject(new EditLineRequest()
         {
             AffectedFeatures = new List<NgisFeature>(),
             Feature = NgisFeatureHelper.Copy(LineFeature),
@@ -304,7 +304,7 @@ public class GeometryEditTest : TestBase
     [Fact]
     public void MovesNodeOnLineIndex2WithOldFeature()
     {
-        var res = GeometryEdit.EditObject(new EditLineRequest()
+        var res = LineEditor.EditObject(new EditLineRequest()
         {
             AffectedFeatures = new List<NgisFeature>(),
             Feature = NgisFeatureHelper.Copy(LineFeature),
@@ -326,7 +326,7 @@ public class GeometryEditTest : TestBase
     [Fact]
     public void DeletesNodeOnLineWithWithNewFeatureSansEdit()
     {
-        var res = GeometryEdit.EditObject(new EditLineRequest()
+        var res = LineEditor.EditObject(new EditLineRequest()
         {
             Feature = NgisFeatureHelper.Copy(LineFeature),
             NewFeature = NgisFeatureHelper.Copy(LineFeatureSans1)
@@ -340,7 +340,7 @@ public class GeometryEditTest : TestBase
     [Fact]
     public void InsertsNodeOnLineIndex0WithNewFeatureSansEdit()
     {
-        var res = GeometryEdit.EditObject(new EditLineRequest()
+        var res = LineEditor.EditObject(new EditLineRequest()
         {
             Feature = NgisFeatureHelper.Copy(LineFeature),
             NewFeature = NgisFeatureHelper.Copy(LineFeatureNew0)
@@ -354,7 +354,7 @@ public class GeometryEditTest : TestBase
     [Fact]
     public void InsertsNodeOnLineIndex1WithNewFeatureSansEdit()
     {
-        var res = GeometryEdit.EditObject(new EditLineRequest()
+        var res = LineEditor.EditObject(new EditLineRequest()
         {
             Feature = NgisFeatureHelper.Copy(LineFeature),
             NewFeature = NgisFeatureHelper.Copy(LineFeatureNew1)
@@ -370,7 +370,7 @@ public class GeometryEditTest : TestBase
     [Fact]
     public void InsertsNodeOnLineIndex2WithOldFeatureSansEdit()
     {
-        var res = GeometryEdit.EditObject(new EditLineRequest()
+        var res = LineEditor.EditObject(new EditLineRequest()
         {
             Feature = NgisFeatureHelper.Copy(LineFeature),
             NewFeature = NgisFeatureHelper.Copy(LineFeatureNew2),
@@ -387,7 +387,7 @@ public class GeometryEditTest : TestBase
     [Fact]
     public void InsertsNodeOnLineIndex3WithOldFeatureSansEdit()
     {
-        var res = GeometryEdit.EditObject(new EditLineRequest()
+        var res = LineEditor.EditObject(new EditLineRequest()
         {
             Feature = NgisFeatureHelper.Copy(LineFeature),
             NewFeature = NgisFeatureHelper.Copy(LineFeatureNew3)
@@ -403,7 +403,7 @@ public class GeometryEditTest : TestBase
     [Fact]
     public void MovesNodeOnLineIndex2WithOldFeatureSansEdit()
     {
-        var res = GeometryEdit.EditObject(new EditLineRequest()
+        var res = LineEditor.EditObject(new EditLineRequest()
         {
             Feature = NgisFeatureHelper.Copy(LineFeature),
             NewFeature = NgisFeatureHelper.Copy(LineFeatureMoved2)

--- a/DeltGeometriFelleskomponent.Tests/PolygonEditorTest.cs
+++ b/DeltGeometriFelleskomponent.Tests/PolygonEditorTest.cs
@@ -1,0 +1,43 @@
+﻿using Xunit.Abstractions;
+using Xunit;
+using DeltGeometriFelleskomponent.TopologyImplementation;
+using DeltGeometriFelleskomponent.Models;
+using System.Collections.Generic;
+using System.Linq;
+using NetTopologySuite.Geometries;
+
+namespace DeltGeometriFelleskomponent.Tests;
+
+public class PolygonEditorTest : TestBase
+{
+    private readonly ITestOutputHelper output;
+
+    public PolygonEditorTest(ITestOutputHelper output)
+    {
+        // Capturing output in unit tests
+        this.output = output;
+    }
+
+    [Fact]
+    public void EditsPolygonWithOneRingAndNoOtherReferences()
+    {
+        //arrange
+        var line = GetExampleFeature("8");
+        var res = new PolygonCreator().CreatePolygonFromLines(new List<NgisFeature>() { line }, null);
+        var polygon = res.First().AffectedFeatures.First(f => f.Geometry.GeometryType == "Polygon");
+
+        var ring = ((Polygon)polygon.Geometry).Shell.Copy().Coordinates;
+        ring[1].X = ring[1].X + 0.00001;
+        var geometry = new Polygon(new LinearRing(ring));
+
+        //act
+        var result = PolygonEditor.EditPolygon(new EditPolygonRequest() { 
+            Feature = polygon, 
+            AffectedFeatures= new List<NgisFeature> { line },
+            EditedGeometry = geometry
+        });
+
+
+    }
+
+}

--- a/DeltGeometriFelleskomponent.Tests/PolygonEditorTest.cs
+++ b/DeltGeometriFelleskomponent.Tests/PolygonEditorTest.cs
@@ -371,6 +371,7 @@ public class PolygonEditorTest : TestBase
         Assert.Equal(Operation.Replace, editedFeature.Update.Action);
 
         Assert.True(geometry.Equals(editedPolygon));
+        Assert.False(editedPolygon.Holes[0].IsCCW);
         Assert.Equal(NgisFeatureHelper.GetLokalId(createdLines.First()), NgisFeatureHelper.GetInteriors(editedFeature)[0][0]);
     }
 
@@ -422,6 +423,7 @@ public class PolygonEditorTest : TestBase
         Assert.Equal(Operation.Replace, editedFeature.Update.Action);
 
         Assert.True(geometry.Equals(editedPolygon));
+        Assert.False(editedPolygon.Holes[0].IsCCW);
         Assert.Equal(NgisFeatureHelper.GetLokalId(createdLines.First()), NgisFeatureHelper.GetInteriors(editedFeature)[1][0]);
     }
 
@@ -470,6 +472,7 @@ public class PolygonEditorTest : TestBase
         Assert.Equal(Operation.Replace, editedFeature.Update.Action);
 
         Assert.True(geometry.Equals(editedPolygon));
+        Assert.False(editedPolygon.Holes[0].IsCCW);
         Assert.Equal($"-{NgisFeatureHelper.GetLokalId(createdLines.First())}", NgisFeatureHelper.GetInteriors(editedFeature)[0][0]);
     }
 

--- a/DeltGeometriFelleskomponent.Tests/PolygonEditorTest.cs
+++ b/DeltGeometriFelleskomponent.Tests/PolygonEditorTest.cs
@@ -19,25 +19,37 @@ public class PolygonEditorTest : TestBase
     }
 
     [Fact]
-    public void EditsPolygonWithOneRingAndNoOtherReferences()
+    public void EditsPolygonWithOneRingAndNoOtherReferencesByEditingPoint()
     {
-        //arrange
+        //arrange        
+        //build a polygon from a line
         var line = GetExampleFeature("8");
         var res = new PolygonCreator().CreatePolygonFromLines(new List<NgisFeature>() { line }, null);
         var polygon = res.First().AffectedFeatures.First(f => f.Geometry.GeometryType == "Polygon");
 
+        output.WriteLine($"original: {polygon.Geometry}");
+
+        //move one of the vertices of the line and create a new polygon
         var ring = ((Polygon)polygon.Geometry).Shell.Copy().Coordinates;
         ring[1].X = ring[1].X + 0.00001;
         var geometry = new Polygon(new LinearRing(ring));
 
         //act
+        //ie: apply this change
         var result = PolygonEditor.EditPolygon(new EditPolygonRequest() { 
-            Feature = polygon, 
-            AffectedFeatures= new List<NgisFeature> { line },
+            Feature = NgisFeatureHelper.Copy(polygon), 
+            AffectedFeatures = new List<NgisFeature> { line },
             EditedGeometry = geometry
         });
 
+        //assert
+
+        var editedPolygon = result.AffectedFeatures.FirstOrDefault(f => f.Geometry.GeometryType == "Polygon");
+
+        Assert.Equal(((Polygon)polygon.Geometry).Shell.Coordinates[1].X + 0.00001, ((Polygon)editedPolygon.Geometry).Shell.Coordinates[1].X);
+        output.WriteLine($"edited:   {editedPolygon.Geometry}");
 
     }
 
+    
 }

--- a/DeltGeometriFelleskomponent.Tests/PolygonEditorTest.cs
+++ b/DeltGeometriFelleskomponent.Tests/PolygonEditorTest.cs
@@ -51,5 +51,39 @@ public class PolygonEditorTest : TestBase
 
     }
 
-    
+    [Fact]
+    public void EditsPolygonWithOneRingAndNoOtherReferencesByRemovingPoint()
+    {
+        //arrange        
+        //build a polygon from a line
+        var line = GetExampleFeature("8");
+        var res = new PolygonCreator().CreatePolygonFromLines(new List<NgisFeature>() { line }, null);
+        var polygon = res.First().AffectedFeatures.First(f => f.Geometry.GeometryType == "Polygon");
+
+        output.WriteLine($"original: {polygon.Geometry}");
+
+        //move one of the vertices of the line and create a new polygon
+        var ring = ((Polygon)polygon.Geometry).Shell.Copy().Coordinates.ToList();
+        ring.RemoveAt(1);
+        var geometry = new Polygon(new LinearRing(ring.ToArray()));
+
+        //act
+        //ie: apply this change
+        var result = PolygonEditor.EditPolygon(new EditPolygonRequest()
+        {
+            Feature = NgisFeatureHelper.Copy(polygon),
+            AffectedFeatures = new List<NgisFeature> { line },
+            EditedGeometry = geometry
+        });
+
+        //assert
+
+        var editedPolygon = result.AffectedFeatures.FirstOrDefault(f => f.Geometry.GeometryType == "Polygon");
+
+        Assert.Equal(((Polygon)polygon.Geometry).Shell.Coordinates.Length -1, ((Polygon)editedPolygon.Geometry).Shell.Coordinates.Length);
+        output.WriteLine($"edited:   {editedPolygon.Geometry}");
+
+    }
+
+
 }

--- a/DeltGeometriFelleskomponent.Tests/PolygonEditorTest.cs
+++ b/DeltGeometriFelleskomponent.Tests/PolygonEditorTest.cs
@@ -46,7 +46,7 @@ public class PolygonEditorTest : TestBase
 
         var editedPolygon = result.AffectedFeatures.FirstOrDefault(f => f.Geometry.GeometryType == "Polygon");
 
-        Assert.Equal(((Polygon)polygon.Geometry).Shell.Coordinates[1].X + 0.00001, ((Polygon)editedPolygon.Geometry).Shell.Coordinates[1].X);
+        Assert.Equal(((Polygon)polygon.Geometry).Shell.Coordinates[1].X + 0.00001, ((Polygon)editedPolygon.Geometry).Shell.Coordinates[1].X, 8);
         output.WriteLine($"edited:   {editedPolygon.Geometry}");
 
     }

--- a/DeltGeometriFelleskomponent.Tests/PolygonEditorTest.cs
+++ b/DeltGeometriFelleskomponent.Tests/PolygonEditorTest.cs
@@ -48,9 +48,16 @@ public class PolygonEditorTest : TestBase
 
         var (editedFeature, editedPolygon) = GetEdited(result.AffectedFeatures);
         output.WriteLine($"edited:   {editedPolygon}");
+
+        Assert.Equal(Operation.Replace, NgisFeatureHelper.GetOperation(editedFeature));
+        Assert.Equal(id, NgisFeatureHelper.GetLokalId(editedFeature));
+
         Assert.Equal(((Polygon)polygon.Geometry).Shell.Coordinates.Length, editedPolygon.Shell.Coordinates.Length);
         Assert.Contains(editedPolygon.Shell.Coordinates, c => c.Equals(newVertex));
         Assert.DoesNotContain(editedPolygon.Shell.Coordinates, c => c.Equals(oldVertex));
+
+        var editedLines = result.AffectedFeatures.Where(f => f.Update?.Action == Operation.Replace && f.Geometry.GeometryType == "LineString");
+        Assert.Single(editedLines);
 
     }
 
@@ -82,9 +89,15 @@ public class PolygonEditorTest : TestBase
         Assert.True(result.IsValid);
         var (editedFeature, editedPolygon) = GetEdited(result.AffectedFeatures);
 
+        Assert.Equal(Operation.Replace, NgisFeatureHelper.GetOperation(editedFeature));
+        Assert.Equal(id, NgisFeatureHelper.GetLokalId(editedFeature));
+
         output.WriteLine($"edited:   {editedPolygon}");
         Assert.Equal(((Polygon)polygon.Geometry).Shell.Coordinates.Length - 1, editedPolygon.Shell.Coordinates.Length);
-        Assert.DoesNotContain(editedPolygon.Shell.Coordinates, c => c.Equals(oldVertex));        
+        Assert.DoesNotContain(editedPolygon.Shell.Coordinates, c => c.Equals(oldVertex));
+
+        var editedLines = result.AffectedFeatures.Where(f => f.Update?.Action == Operation.Replace && f.Geometry.GeometryType == "LineString");
+        Assert.Single(editedLines);
     }
 
     [Fact]
@@ -116,9 +129,15 @@ public class PolygonEditorTest : TestBase
         Assert.True(result.IsValid);
 
         var (editedFeature, editedPolygon) = GetEdited(result.AffectedFeatures);
+        Assert.Equal(Operation.Replace, NgisFeatureHelper.GetOperation(editedFeature));
+        Assert.Equal(id, NgisFeatureHelper.GetLokalId(editedFeature));
+
         Assert.Equal(((Polygon)polygon.Geometry).Shell.Coordinates.Length + 1, editedPolygon.Shell.Coordinates.Length);
         Assert.Contains(editedPolygon.Shell.Coordinates, c => c.Equals(newVertex));
         Assert.Contains(editedPolygon.Shell.Coordinates, c => c.Equals(oldVertex));
+
+        var editedLines = result.AffectedFeatures.Where(f => f.Update?.Action == Operation.Replace && f.Geometry.GeometryType == "LineString");
+        Assert.Single(editedLines);
     }
 
     [Fact]
@@ -157,10 +176,16 @@ public class PolygonEditorTest : TestBase
         var (editedFeature, editedPolygon) = GetEdited(result.AffectedFeatures);
         output.WriteLine($"edited:   {editedPolygon}");
 
+        Assert.Equal(Operation.Replace, NgisFeatureHelper.GetOperation(editedFeature));
+        Assert.Equal(id, NgisFeatureHelper.GetLokalId(editedFeature));
+
         Assert.Equal(((Polygon)polygon.Geometry).Shell.Coordinates.Length, editedPolygon.Shell.Coordinates.Length);
 
         Assert.Contains(editedPolygon.Shell.Coordinates, c => c.Equals(newVertex));
         Assert.DoesNotContain(editedPolygon.Shell.Coordinates, c => c.Equals(oldVertex));
+
+        var editedLines = result.AffectedFeatures.Where(f => f.Update?.Action == Operation.Replace && f.Geometry.GeometryType == "LineString");
+        Assert.Single(editedLines);
     }
 
     [Fact]
@@ -199,11 +224,15 @@ public class PolygonEditorTest : TestBase
 
         var (editedFeature, editedPolygon) = GetEdited(result.AffectedFeatures);
         output.WriteLine($"edited:   {editedPolygon}");
-
+        Assert.Equal(Operation.Replace, NgisFeatureHelper.GetOperation(editedFeature));
+        Assert.Equal(id, NgisFeatureHelper.GetLokalId(editedFeature));
         Assert.Equal(((Polygon)polygon.Geometry).Shell.Coordinates.Length, editedPolygon.Shell.Coordinates.Length);
 
         Assert.Contains(editedPolygon.Shell.Coordinates, c => c.Equals(newVertex));
         Assert.DoesNotContain(editedPolygon.Shell.Coordinates, c => c.Equals(oldVertex));
+
+        var editedLines = result.AffectedFeatures.Where(f => f.Update?.Action == Operation.Replace && f.Geometry.GeometryType == "LineString");
+        Assert.Equal(2, editedLines.Count());
     }
 
     [Fact]
@@ -240,10 +269,15 @@ public class PolygonEditorTest : TestBase
 
         var (editedFeature, editedPolygon) = GetEdited(result.AffectedFeatures);
         output.WriteLine($"edited:   {editedPolygon}");
+        Assert.Equal(Operation.Replace, NgisFeatureHelper.GetOperation(editedFeature));
+        Assert.Equal(id, NgisFeatureHelper.GetLokalId(editedFeature));
 
         Assert.Equal(((Polygon)polygon.Geometry).Shell.Coordinates.Length - 1, editedPolygon.Shell.Coordinates.Length);
 
         Assert.DoesNotContain(editedPolygon.Shell.Coordinates, c => c.Equals(oldVertex));
+
+        var editedLines = result.AffectedFeatures.Where(f => f.Update?.Action == Operation.Replace && f.Geometry.GeometryType == "LineString");
+        Assert.Single(editedLines);
     }
 
     [Fact]
@@ -281,11 +315,15 @@ public class PolygonEditorTest : TestBase
 
         var (editedFeature, editedPolygon) = GetEdited(result.AffectedFeatures);
         output.WriteLine($"edited:   {editedPolygon}");
-
+        Assert.Equal(Operation.Replace, NgisFeatureHelper.GetOperation(editedFeature));
+        Assert.Equal(id, NgisFeatureHelper.GetLokalId(editedFeature));
         Assert.Equal(((Polygon)polygon.Geometry).Shell.Coordinates.Length + 1, editedPolygon.Shell.Coordinates.Length);
 
         Assert.Contains(editedPolygon.Shell.Coordinates, c => c.Equals(oldVertex));
         Assert.Contains(editedPolygon.Shell.Coordinates, c => c.Equals(newVertex));
+
+        var editedLines = result.AffectedFeatures.Where(f => f.Update?.Action == Operation.Replace && f.Geometry.GeometryType == "LineString");
+        Assert.Equal(2, editedLines.Count());
     }
 
     [Fact]

--- a/DeltGeometriFelleskomponent.Tests/TopologyImplementationTest.cs
+++ b/DeltGeometriFelleskomponent.Tests/TopologyImplementationTest.cs
@@ -483,7 +483,7 @@ namespace DeltGeometriFelleskomponent.Tests
             lineStringModified[1].Y += 20;
 
             var movedCoordinate = new Coordinate() { X = lineStringModified[1].X, Y = lineStringModified[1].Y };
-            var edited = GeometryEdit.EditObject(new EditLineRequest()
+            var edited = LineEditor.EditObject(new EditLineRequest()
             {
                 AffectedFeatures = affectedFeatures,
                 Feature = lineFeature1,
@@ -520,7 +520,7 @@ namespace DeltGeometriFelleskomponent.Tests
 
             var coordinateCount1 = lineFeature1.Geometry.Coordinates.Length;
 
-            var edited = GeometryEdit.EditObject(new EditLineRequest()
+            var edited = LineEditor.EditObject(new EditLineRequest()
             {
                 AffectedFeatures = affectedFeatures,
                 Feature = lineFeature1,

--- a/DeltGeometriFelleskomponent.TopologyImplementation/CoordinateHelper.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/CoordinateHelper.cs
@@ -1,0 +1,27 @@
+﻿
+using DeltGeometriFelleskomponent.Models;
+using NetTopologySuite.Geometries;
+
+namespace DeltGeometriFelleskomponent.TopologyImplementation;
+
+public static class CoordinateHelper
+{
+    public static IEnumerable<Coordinate> GetCoordinatesNotIn(LinearRing a, LinearRing b)
+       => a.Coordinates[..^1].Where(c => !b.Coordinates[..^1].Any(c2 => c.Equals(c2)));
+
+    public static int FindCoordinateIndex(Coordinate[] coordinates, Coordinate coord)
+        => Array.FindIndex(coordinates, c => c.Equals(coord));
+
+    public static Coordinate? GetClosestCoordinate(IEnumerable<Coordinate> cooordinates, Coordinate targetCoordinate)
+    {
+        var distances = cooordinates.Select(p => (p.Distance(targetCoordinate), p));
+        return distances.Count() > 0 ? distances.Min().Item2 : null;
+    }
+
+    public static NgisFeature? GetFirstFeatureWithCoordinate(Coordinate coordinate, IEnumerable<NgisFeature> referencedFeatures)
+       => referencedFeatures.FirstOrDefault(f => f.Geometry.Coordinates.Any(c2 => c2.Equals(coordinate)));
+
+    public static LinearRing[] GetRingsNotIn(LinearRing[] a, LinearRing[] b)
+        => b.Where(r => !a.Any(x => x.Equals(r))).ToArray();
+}
+

--- a/DeltGeometriFelleskomponent.TopologyImplementation/ITopologyImplementation.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/ITopologyImplementation.cs
@@ -10,5 +10,7 @@ public interface ITopologyImplementation
 
     TopologyResponse EditLine(EditLineRequest request);
 
+    TopologyResponse EditPolygon(EditPolygonRequest request);
+
     //TopologyResponse CreatePolygonFromGeometry(ToplogyRequest request);
 }

--- a/DeltGeometriFelleskomponent.TopologyImplementation/LineEditor.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/LineEditor.cs
@@ -1,12 +1,10 @@
-﻿using System.Linq;
-using DeltGeometriFelleskomponent.Models;
-using NetTopologySuite.Features;
+﻿using DeltGeometriFelleskomponent.Models;
 using NetTopologySuite.Geometries;
 
 
 namespace DeltGeometriFelleskomponent.TopologyImplementation
 {
-    public class GeometryEdit
+    public class LineEditor
     {
         private static readonly PolygonCreator _polygonCreator = new();
 

--- a/DeltGeometriFelleskomponent.TopologyImplementation/PolygonCreator.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/PolygonCreator.cs
@@ -1,4 +1,5 @@
 ﻿using DeltGeometriFelleskomponent.Models;
+using DeltGeometriFelleskomponent.Models.Exceptions;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.IO;
 using NetTopologySuite.Operation.Polygonize;
@@ -177,7 +178,7 @@ public class PolygonCreator
         {
             return new FeatureWithDirection { Feature = reversed, IsReversed = true };
         }
-        throw new Exception("should not happen!");
+        throw new ExceptionWithHttpStatusCode("Unable to build polygon!", System.Net.HttpStatusCode.InternalServerError);
     }
 
     private static bool StartsAtPosition(Coordinate[] coords, int index, Geometry line)

--- a/DeltGeometriFelleskomponent.TopologyImplementation/PolygonCreator.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/PolygonCreator.cs
@@ -126,7 +126,7 @@ public class PolygonCreator
         return interiorFeatures;
     }
 
-    private static NgisFeature CreateInteriorFeature(LineString ring)
+    public static NgisFeature CreateInteriorFeature(LineString ring)
     {
         var interiorFeature = NgisFeatureHelper.CreateFeature(ring);
         NgisFeatureHelper.SetOperation(interiorFeature, Operation.Create);

--- a/DeltGeometriFelleskomponent.TopologyImplementation/PolygonEditor.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/PolygonEditor.cs
@@ -14,7 +14,7 @@ public static class PolygonEditor
         }
 
         var shellEdits = GetShellEdits(request);
-        var holeEdits = GetHoleEdits(request);
+        var holeEdits = PolygonHoleEditor.GetHoleEdits(request);
 
         var editCount = shellEdits.Count() + holeEdits.Count();
 
@@ -27,193 +27,31 @@ public static class PolygonEditor
             throw new Exception("Multiple edits found. Not supported!");
         }
 
-
-        if (shellEdits.Count() > 0)
-        {
-            return LineEditor.EditLine(shellEdits.First());
-        }
-        return ApplyHoleEdit(holeEdits.First());
-
+        return shellEdits.Count() > 0
+            ? LineEditor.EditLine(shellEdits.First())
+            : PolygonHoleEditor.EditHole(holeEdits.First());        
     }
 
-    private static TopologyResponse ApplyHoleEdit(HoleEdit edit)
-    {
-        if (edit.Operation == EditOperation.Edit)
+    public static IEnumerable<EditLineRequest> CreateEditLineRequests(IEnumerable<Change> changes, IEnumerable<NgisFeature> referencedFeatures, NgisFeature editedPolygonFeature, LinearRing ring)
+        => changes.Select(change =>
         {
-            if (!edit.Index.HasValue)
+            var referencedLineFeature = GetLineFeatureAffectedByChange(change, referencedFeatures, ring);
+            if (referencedLineFeature == null)
             {
-                throw new Exception("Missing index");
+                return null;
             }
-            
-            var feature = edit.Feature;
-            var polygon = (Polygon)feature.Geometry;
 
-            var oldRing = polygon.Holes[edit.Index.Value];
-            var newRing = edit.Ring;
-            var edits = ToEdits(GetChanges(oldRing, newRing), GetFeaturesReferencedByPolygon(feature, edit.AffectedFeatures), feature, oldRing);
-            if (edits.Count() > 1)
+            var edit = CreateEditLineRequest(change, referencedLineFeature);
+            if (edit == null)
             {
-                throw new Exception("Multiple edits found. Not supported!");
+                return null;
             }
-            return LineEditor.EditLine(edits.First());
-            
-        }        
-        Func<HoleEdit, List<NgisFeature>> func = edit.Operation == EditOperation.Insert ? AddHole : RemoveHole;
-        return new TopologyResponse()
-        {
-            IsValid = true,
-            AffectedFeatures = func(edit).Concat(edit.AffectedFeatures != null ? edit.AffectedFeatures : new List<NgisFeature>()).ToList()
-        };
-    }
 
-    private static List<NgisFeature> AddHole(HoleEdit edit)
-    {        
-        var feature = edit.Feature;
-        var polygon = (Polygon)feature.Geometry;
+            edit.AffectedFeatures = new List<NgisFeature>() { editedPolygonFeature }.Concat(referencedFeatures.Where(f => NgisFeatureHelper.GetLokalId(referencedLineFeature) != NgisFeatureHelper.GetLokalId(f))).ToList();
+            return edit;
+        }).OfType<EditLineRequest>();
 
-        var hole = PolygonCreator.CreateInteriorFeature(new LineString(edit.Ring.Coordinates));
-        var ring = new LinearRing(hole.Geometry.Coordinates);
-
-        var isReversed = ring.IsCCW;
-
-        var holes = polygon.Holes.ToList();
-        holes.Add(ring);        
-
-        feature.Geometry = PolygonCreator.EnsureOrdering(new Polygon(polygon.Shell, holes.ToArray()));
-        var interiors = NgisFeatureHelper.GetInteriors(feature);
-        interiors.Add(new List<string>() { $"{(isReversed ? "-" : "")}{NgisFeatureHelper.GetLokalId(hole)}" });
-        NgisFeatureHelper.SetInterior(feature, interiors);        
-        NgisFeatureHelper.SetOperation(feature, Operation.Replace);
-
-        return new List<NgisFeature>() { feature, hole};
-    }
-
-    private static List<NgisFeature> RemoveHole(HoleEdit edit)
-    {
-        var feature = edit.Feature;
-        var shell = ((Polygon)feature.Geometry).Shell;
-        var holes = ((Polygon)feature.Geometry).Holes.Where(h => !h.Equals(edit.Ring)).ToArray();
-        feature.Geometry = new Polygon(shell, holes);
-
-        NgisFeatureHelper.SetOperation(feature, Operation.Replace);
-
-        var ringFeature = edit.AffectedFeatures?.FirstOrDefault(f => f.Geometry.Equals(edit.Ring));
-        var ringFeatureId = ringFeature != null ? NgisFeatureHelper.GetLokalId(ringFeature) : null;
-        var interiors = NgisFeatureHelper.GetInteriors(feature);
-
-        NgisFeatureHelper.SetInterior(feature, ringFeatureId != null ? interiors.Where(h => !h.Select(NgisFeatureHelper.RemoveSign).Contains(ringFeatureId)).ToArray() : interiors);
-        return new List<NgisFeature>() { feature };
-    }
-
-    private static IEnumerable<EditLineRequest> GetShellEdits(EditPolygonRequest request)
-    {
-        var oldPolygon = (Polygon)request.Feature.Geometry;
-        var newPolygon = request.EditedGeometry;
-
-        var changes = GetChanges(oldPolygon.Shell, newPolygon.Shell);
-
-        return ToEdits(changes, GetFeaturesReferencedByPolygon(request.Feature, request.AffectedFeatures), request.Feature, oldPolygon.Shell).OfType<EditLineRequest>();
-    }
-
-    private static LinearRing[] GetHoles(Polygon polygon)
-        => polygon.Holes ?? new LinearRing[] {};
-    
-    private static LinearRing GetMostSimilarHole(LinearRing[] candidates, LinearRing hole)
-    {
-        return candidates[0];
-    }
-
-    private static IEnumerable<HoleEdit> GetHoleEdits(EditPolygonRequest request)
-    {
-        var oldHoles = GetHoles((Polygon)request.Feature.Geometry);
-        var newHoles = GetHoles(request.EditedGeometry);
-
-        if (oldHoles.Count() == newHoles.Count())
-        {
-            var changedHoles = newHoles.Where(h => !oldHoles.Any(oh => oh.Equals(h)));
-            var edits = new List<HoleEdit>();
-            var holes = GetHoles((Polygon)request.Feature.Geometry);
-            foreach (var changedHole in changedHoles)
-            {
-                var oldHole = GetMostSimilarHole(oldHoles, changedHole);
-                oldHoles = oldHoles.Where(h => !h.Equals(oldHole)).ToArray();
-
-                edits.Add(new HoleEdit()
-                {
-                    Operation = EditOperation.Edit,
-                    Feature = request.Feature,
-                    AffectedFeatures = request.AffectedFeatures,
-                    Index = Array.FindIndex(holes, c => c.Equals(oldHole)),
-                    Ring = changedHole
-                });
-            }
-            return edits;
-
-        }
-        if (oldHoles.Count() < newHoles.Count())
-        {
-            return GetRingsNotIn(oldHoles, newHoles).Select(hole => new HoleEdit()
-            {
-                Operation = EditOperation.Insert,
-                Ring = hole,
-                Feature = request.Feature,
-                AffectedFeatures = request.AffectedFeatures
-            }).ToList();
-           
-        }
-        if (oldHoles.Count() > newHoles.Count())
-        {
-            return GetRingsNotIn(newHoles,oldHoles).Select(hole => new HoleEdit()
-            {
-                Operation = EditOperation.Delete,
-                Ring = hole,
-                Feature = request.Feature,
-                AffectedFeatures = request.AffectedFeatures
-            }).ToList();
-        }
-
-        return new List<HoleEdit>();
-    }
-
-    private static LinearRing[] GetRingsNotIn(LinearRing[] a, LinearRing[] b)
-        => b.Where(r => !a.Any(x => x.Equals(r))).ToArray();
-
-    private static IEnumerable<EditLineRequest> ToEdits(IEnumerable<Change> changes, IEnumerable<NgisFeature> referencedFeatures, NgisFeature editedPolygonFeature, LinearRing ring)
-    {
-        var res = new List<EditLineRequest>();
-        foreach (var change in changes)
-        {
-
-            var referencedLineFeature = GetLineForEditPair(change, referencedFeatures, ring);
-            if (referencedLineFeature != null) { 
-                var edit = ToEdit(change, referencedLineFeature);
-                if (edit != null) { 
-                    edit.AffectedFeatures = new List<NgisFeature>() { editedPolygonFeature }.Concat( referencedFeatures.Where(f => NgisFeatureHelper.GetLokalId(referencedLineFeature) != NgisFeatureHelper.GetLokalId(f))).ToList();
-                    res.Add(edit);
-                }
-            }
-        }
-        return res;
-    }
-
-    private static NgisFeature? GetLineForEditPair(Change change, IEnumerable<NgisFeature> referencedFeatures, LinearRing ring)
-    {        
-        if (change.OldVertex != null)
-        {
-            return GetFirstFeatureWithCoordinate(change.OldVertex, referencedFeatures);
-        }
-        else if (change.NewVertexPrevIndex.HasValue)
-        {
-            var coord = change.NewVertexPrevIndex.Value != -1 ? ring.Coordinates[change.NewVertexPrevIndex.Value] : ring.Coordinates.Last();
-            return GetFirstFeatureWithCoordinate(coord, referencedFeatures);
-        }
-        return null;
-    }
-
-    private static NgisFeature? GetFirstFeatureWithCoordinate(Coordinate coordinate, IEnumerable<NgisFeature> referencedFeatures)
-        => referencedFeatures.FirstOrDefault(f => f.Geometry.Coordinates.Any(c2 => c2.Equals(coordinate)));
-
-    private static IEnumerable<NgisFeature> GetFeaturesReferencedByPolygon(NgisFeature feature, List<NgisFeature>? affectedFeatures)
+    public static IEnumerable<NgisFeature> GetFeaturesReferencedByPolygon(NgisFeature feature, List<NgisFeature>? affectedFeatures)
     {
         if (affectedFeatures == null)
         {
@@ -225,14 +63,65 @@ public static class PolygonEditor
         var references = affectedFeatures
             .Where(f => f.Geometry.GeometryType == "Polygon")
             .Where(p => NgisFeatureHelper.GetAllReferences(p).Any(r => directReferences.Contains(r)))
-            .Select(p => new List<string>() {NgisFeatureHelper.GetLokalId(p) }.Concat(NgisFeatureHelper.GetAllReferences(p)))
+            .Select(p => new List<string>() { NgisFeatureHelper.GetLokalId(p) }.Concat(NgisFeatureHelper.GetAllReferences(p)))
             .SelectMany(p => p)
             .Concat(directReferences)
             .Distinct();
         return affectedFeatures.FindAll(f => references.Any(id => id == NgisFeatureHelper.GetLokalId(f)));
     }
 
-    private static EditLineRequest? ToEdit(Change change, NgisFeature feature)
+    public static IEnumerable<Change> GetChangesToRing(LinearRing oldRing, LinearRing newRing)
+    {
+        var deletedVertices = CoordinateHelper.GetCoordinatesNotIn(oldRing, newRing);
+        var newVertices = CoordinateHelper.GetCoordinatesNotIn(newRing, oldRing);
+
+        var changes = new List<Change>();
+
+        foreach (var deletedVertex in deletedVertices)
+        {
+            var newVertex = CoordinateHelper.GetClosestCoordinate(newVertices, deletedVertex);
+            changes.Add(new Change()
+            {
+                OldVertex = deletedVertex,
+                NewVertex = newVertex,
+            });
+            newVertices = newVertices.Where(c => !c.Equals(newVertex));
+        }
+        foreach (var addedVertex in newVertices)
+        {
+            changes.Add(new Change()
+            {
+                OldVertex = null,
+                NewVertex = addedVertex,
+                NewVertexPrevIndex = CoordinateHelper.FindCoordinateIndex(newRing.Coordinates, addedVertex) - 1
+            });
+        }
+        return changes;
+    }
+
+    private static IEnumerable<EditLineRequest> GetShellEdits(EditPolygonRequest request)
+    {
+        var oldPolygon = (Polygon)request.Feature.Geometry;
+        var newPolygon = request.EditedGeometry;
+        var changes = GetChangesToRing(oldPolygon.Shell, newPolygon.Shell);
+        return CreateEditLineRequests(changes, GetFeaturesReferencedByPolygon(request.Feature, request.AffectedFeatures), request.Feature, oldPolygon.Shell).OfType<EditLineRequest>();
+    }
+
+    private static NgisFeature? GetLineFeatureAffectedByChange(Change change, IEnumerable<NgisFeature> referencedFeatures, LinearRing ring)
+    {        
+        if (change.OldVertex != null)
+        {
+            return CoordinateHelper.GetFirstFeatureWithCoordinate(change.OldVertex, referencedFeatures);
+        }
+        else if (change.NewVertexPrevIndex.HasValue)
+        {
+            var coord = change.NewVertexPrevIndex.Value != -1 ? ring.Coordinates[change.NewVertexPrevIndex.Value] : ring.Coordinates.Last();
+            return CoordinateHelper.GetFirstFeatureWithCoordinate(coord, referencedFeatures);
+        }
+        return null;
+    }
+
+    private static EditLineRequest? CreateEditLineRequest(Change change, NgisFeature feature)
     {
         if (change.NewVertex != null && change.OldVertex != null) { 
 
@@ -243,7 +132,7 @@ public static class PolygonEditor
                 {
                     Operation = EditOperation.Edit,
                     NodeValue = new List<double>() { change.NewVertex.X, change.NewVertex.Y },
-                    NodeIndex = FindIndex(feature.Geometry.Coordinates, change.OldVertex)
+                    NodeIndex = CoordinateHelper.FindCoordinateIndex(feature.Geometry.Coordinates, change.OldVertex)
                 }
             };
         }
@@ -255,7 +144,7 @@ public static class PolygonEditor
                 Edit = new EditLineOperation()
                 {
                     Operation = EditOperation.Delete,                    
-                    NodeIndex = FindIndex(feature.Geometry.Coordinates,change.OldVertex)
+                    NodeIndex = CoordinateHelper.FindCoordinateIndex(feature.Geometry.Coordinates,change.OldVertex)
                 }
             };
         }
@@ -275,55 +164,15 @@ public static class PolygonEditor
         return null;
     }
 
-    private static IEnumerable<Coordinate> GetCoordsNotIn(LinearRing a, LinearRing b) 
-        => a.Coordinates[..^1].Where(c => !b.Coordinates[..^1].Any(c2 => c.Equals(c2)));
 
-    private static IEnumerable<Change> GetChanges (LinearRing oldRing, LinearRing newRing)
-    {
-        var deletedVertices = GetCoordsNotIn(oldRing, newRing);
-        var newVertices = GetCoordsNotIn(newRing, oldRing);
 
-        var changes = new List<Change>();
-        
-        foreach (var deletedVertex in deletedVertices)
-        {
-            var newVertex = GetClosest(newVertices, deletedVertex);
-            changes.Add(new Change()
-            {
-                OldVertex = deletedVertex,
-                NewVertex = newVertex,
-            });
-            newVertices = newVertices.Where(c => !c.Equals(newVertex));
-        }
-        foreach (var addedVertex in newVertices)
-        {
-            changes.Add(new Change()
-            {
-                OldVertex = null,
-                NewVertex = addedVertex,
-                NewVertexPrevIndex = FindIndex(newRing.Coordinates, addedVertex) - 1
-            });
-        }
-
-        return changes;
-    }
-
-    private static int FindIndex(Coordinate[] coordinates, Coordinate coord)
-        => Array.FindIndex(coordinates, c => c.Equals(coord));
-
-    private static Coordinate? GetClosest (IEnumerable<Coordinate> cooordinates, Coordinate targetCoordinate)
-    {
-        var distances = cooordinates.Select(p => (p.Distance(targetCoordinate), p));
-        return distances.Count() > 0 ? distances.Min().Item2 : null;
-    }
-
-    internal class Change {
+    public class Change {
         public Coordinate? OldVertex { get; set; }
         public Coordinate? NewVertex { get; set; }
         public int? NewVertexPrevIndex { get; set; }
     }
 
-    internal class HoleEdit
+    public class HoleEditRequest
     {
         public int? Index { get; set; }
         public EditOperation Operation { get; set; }

--- a/DeltGeometriFelleskomponent.TopologyImplementation/PolygonEditor.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/PolygonEditor.cs
@@ -1,4 +1,5 @@
 ﻿using DeltGeometriFelleskomponent.Models;
+using DeltGeometriFelleskomponent.Models.Exceptions;
 using NetTopologySuite.Geometries;
 
 namespace DeltGeometriFelleskomponent.TopologyImplementation;
@@ -10,7 +11,7 @@ public static class PolygonEditor
 
         if (request.Feature.Geometry.GeometryType != "Polygon")
         {
-            throw new Exception("Can only edit polygons");
+            throw new BadRequestException("Can only edit polygons");
         }
 
         var shellEdits = GetShellEdits(request);
@@ -20,11 +21,11 @@ public static class PolygonEditor
 
         if (editCount == 0)
         {
-            throw new Exception("No edits found");
+            throw new BadRequestException("No edits found");
         }
         if (editCount > 1)
         {
-            throw new Exception("Multiple edits found. Not supported!");
+            throw new BadRequestException("Multiple edits found. Not supported!");
         }
 
         return shellEdits.Count() > 0

--- a/DeltGeometriFelleskomponent.TopologyImplementation/PolygonEditor.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/PolygonEditor.cs
@@ -47,7 +47,7 @@ public static class PolygonEditor
             if (referencedLineFeature != null) { 
                 var edit = ToEdit(pair, referencedLineFeature);
                 if (edit != null) { 
-                    edit.AffectedFeatures = new List<NgisFeature>() { editedPolygonFeature }.Concat( referencedFeatures.Where(f => NgisFeatureHelper.GetLokalId(f) != NgisFeatureHelper.GetLokalId(f))).ToList();
+                    edit.AffectedFeatures = new List<NgisFeature>() { editedPolygonFeature }.Concat( referencedFeatures.Where(f => NgisFeatureHelper.GetLokalId(referencedLineFeature) != NgisFeatureHelper.GetLokalId(f))).ToList();
                     res.Add(edit);
                 }
             }

--- a/DeltGeometriFelleskomponent.TopologyImplementation/PolygonEditor.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/PolygonEditor.cs
@@ -60,10 +60,14 @@ public static class PolygonEditor
         var polygon = (Polygon)feature.Geometry;        
         var holes = polygon.Holes.ToList();
         var ring = new LinearRing(hole.Geometry.Coordinates);
+
+        var reverse = ring.IsCCW;
+        
+
         holes.Add(ring);        
         feature.Geometry = PolygonCreator.EnsureOrdering(new Polygon(polygon.Shell, holes.ToArray()));
         var interiors = NgisFeatureHelper.GetInteriors(feature);
-        interiors.Add(new List<string>() { NgisFeatureHelper.GetLokalId(hole) });
+        interiors.Add(new List<string>() { $"{(reverse ? "-" : "")}{NgisFeatureHelper.GetLokalId(hole)}" });
         NgisFeatureHelper.SetInterior(feature, interiors);
         return feature;
     }

--- a/DeltGeometriFelleskomponent.TopologyImplementation/PolygonEditor.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/PolygonEditor.cs
@@ -93,7 +93,7 @@ public static class PolygonEditor
         var ringFeatureId = ringFeature != null ? NgisFeatureHelper.GetLokalId(ringFeature) : null;
         var interiors = NgisFeatureHelper.GetInteriors(feature);
 
-        NgisFeatureHelper.SetInterior(feature, ringFeatureId != null ? interiors.Where(h => !h.Contains(ringFeatureId)).ToArray() : interiors);
+        NgisFeatureHelper.SetInterior(feature, ringFeatureId != null ? interiors.Where(h => !h.Select(NgisFeatureHelper.RemoveSign).Contains(ringFeatureId)).ToArray() : interiors);
         return new List<NgisFeature>() { feature };
     }
 

--- a/DeltGeometriFelleskomponent.TopologyImplementation/PolygonEditor.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/PolygonEditor.cs
@@ -1,0 +1,23 @@
+﻿using DeltGeometriFelleskomponent.Models;
+using NetTopologySuite.Geometries;
+
+namespace DeltGeometriFelleskomponent.TopologyImplementation;
+
+public static class PolygonEditor
+{
+    public static TopologyResponse EditPolygon(EditPolygonRequest request)
+    {
+        
+        if (request.Feature.Geometry.GeometryType != "Polygon")
+        {
+            throw new Exception("Can only edit polygons");
+        }
+        var oldPolygon = (Polygon )request.Feature.Geometry;
+        var newPolygon = request.EditedGeometry; ;
+
+
+
+        throw new NotImplementedException();
+    }
+}
+

--- a/DeltGeometriFelleskomponent.TopologyImplementation/PolygonEditor.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/PolygonEditor.cs
@@ -1,7 +1,5 @@
 ﻿using DeltGeometriFelleskomponent.Models;
 using NetTopologySuite.Geometries;
-using System.Linq;
-using System.Net.NetworkInformation;
 
 namespace DeltGeometriFelleskomponent.TopologyImplementation;
 

--- a/DeltGeometriFelleskomponent.TopologyImplementation/PolygonEditor.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/PolygonEditor.cs
@@ -30,7 +30,7 @@ public static class PolygonEditor
     private static IEnumerable<EditLineRequest> GetShellEdits(EditPolygonRequest request)
     {
         var oldPolygon = (Polygon)request.Feature.Geometry;
-        var newPolygon = request.EditedGeometry; ;
+        var newPolygon = request.EditedGeometry;
 
         var pairs = GetPairs(oldPolygon.Shell, newPolygon.Shell);
 
@@ -122,7 +122,7 @@ public static class PolygonEditor
     }
 
     private static IEnumerable<Coordinate> GetCoordsNotIn(LinearRing a, LinearRing b) 
-        => a.Coordinates.Where(c => !b.Coordinates.Any(c2 => c.Equals(c2)));
+        => a.Coordinates[..^1].Where(c => !b.Coordinates[..^1].Any(c2 => c.Equals(c2)));
 
     private static IEnumerable<Pair> GetPairs (LinearRing oldRing, LinearRing newRing)
     {

--- a/DeltGeometriFelleskomponent.TopologyImplementation/PolygonEditor.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/PolygonEditor.cs
@@ -7,17 +7,106 @@ public static class PolygonEditor
 {
     public static TopologyResponse EditPolygon(EditPolygonRequest request)
     {
-        
+
         if (request.Feature.Geometry.GeometryType != "Polygon")
         {
             throw new Exception("Can only edit polygons");
         }
-        var oldPolygon = (Polygon )request.Feature.Geometry;
+        var oldPolygon = (Polygon)request.Feature.Geometry;
         var newPolygon = request.EditedGeometry; ;
 
+        var pairs = GetPairs(oldPolygon.Shell, newPolygon.Shell);
+        var lines = GetShellFeatures(request.Feature, request.AffectedFeatures);
+        var edits = ToEdits(pairs, lines, request.Feature);
+
+
+        if (edits.Count() == 1)
+        {
+            return LineEditor.EditLine(edits.First());
+        }
 
 
         throw new NotImplementedException();
     }
+
+
+    private static IEnumerable<EditLineRequest> ToEdits(IEnumerable<Pair> pairs, IEnumerable<NgisFeature> referencedFeatures, NgisFeature editedPolygonFeature)
+    {
+        var res = new List<EditLineRequest>();
+        foreach (var pair in pairs)
+        {
+            var f = referencedFeatures.FirstOrDefault(f => f.Geometry.Coordinates.Any(c2 => c2.Equals(pair.oldCoord)));
+            if (f != null) { 
+                var edit = ToEdit(pair, f);
+                edit.AffectedFeatures = new List<NgisFeature>() { editedPolygonFeature }.Concat( referencedFeatures.Where(f => NgisFeatureHelper.GetLokalId(f) != NgisFeatureHelper.GetLokalId(f))).ToList();
+                res.Add(edit);
+            }
+        }
+        return res;
+    }
+      /*  => pairs.Select(p => {
+
+            var f = referencedFeatures.FirstOrDefault(f => f.Geometry.Coordinates.Any(c2 => c2.Equals(p.oldCoord)));
+
+            var edit = ToEdit(p, f);
+
+            return edit;
+
+        });*/
+
+    private static IEnumerable<NgisFeature> GetShellFeatures(NgisFeature feature, List<NgisFeature> affectedFeatures)
+    {
+        var exteriors = NgisFeatureHelper.GetExteriors(feature).Select(NgisFeatureHelper.RemoveSign);
+        return affectedFeatures.FindAll(f => exteriors.Any(id => id == NgisFeatureHelper.GetLokalId(f)));
+    }
+
+    private static EditLineRequest ToEdit(Pair pair, NgisFeature feature)
+    {
+
+        return new EditLineRequest()
+        {
+            Feature = feature,
+            Edit = new EditLineOperation()
+            {
+                Operation = EditOperation.Edit,
+                NodeValue = new List<double>() { pair.newCoord.X, pair.newCoord.Y },
+                NodeIndex = Array.FindIndex(feature.Geometry.Coordinates, c => c.Equals(pair.oldCoord))
+            }
+        };
+    }
+
+    private static IEnumerable<Coordinate> GetCoordsNotIn(LinearRing a, LinearRing b) 
+        => a.Coordinates.Where(c => !b.Coordinates.Any(c2 => c.Equals(c2)));
+
+    private static IEnumerable<Pair> GetPairs (LinearRing oldRing, LinearRing newRing)
+    {
+        var deletedPoints = GetCoordsNotIn(oldRing, newRing);
+        var newPoints = GetCoordsNotIn(newRing, oldRing);
+
+        var pairs = new List<Pair>();
+        if (newPoints.Count() == deletedPoints.Count())
+        {
+            foreach (var deletedPoint in deletedPoints)
+            {
+                pairs.Add(new Pair()
+                {
+                    oldCoord = deletedPoint,
+                    newCoord = newPoints.Select(p => (p.Distance(deletedPoint), p)).Min().Item2
+                });
+
+            }
+
+        }
+        return pairs;
+    }
+
+    internal class Pair {
+        public Coordinate? oldCoord { get; set; }
+        public Coordinate? newCoord { get; set; }
+    }
+
+    
+    
 }
+
 

--- a/DeltGeometriFelleskomponent.TopologyImplementation/PolygonHoleEditor.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/PolygonHoleEditor.cs
@@ -1,4 +1,5 @@
 ﻿using DeltGeometriFelleskomponent.Models;
+using DeltGeometriFelleskomponent.Models.Exceptions;
 using NetTopologySuite.Geometries;
 using static DeltGeometriFelleskomponent.TopologyImplementation.PolygonEditor;
 
@@ -12,7 +13,7 @@ public static class PolygonHoleEditor
         {
             if (!edit.Index.HasValue)
             {
-                throw new Exception("Missing index");
+                throw new BadRequestException("Missing index");
             }
 
             var feature = edit.Feature;
@@ -23,7 +24,7 @@ public static class PolygonHoleEditor
             var edits = CreateEditLineRequests(GetChangesToRing(oldRing, newRing), GetFeaturesReferencedByPolygon(feature, edit.AffectedFeatures), feature, oldRing);
             if (edits.Count() > 1)
             {
-                throw new Exception("Multiple edits found. Not supported!");
+                throw new BadRequestException("Multiple edits found. Not supported!");
             }
             return LineEditor.EditLine(edits.First());
 

--- a/DeltGeometriFelleskomponent.TopologyImplementation/PolygonHoleEditor.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/PolygonHoleEditor.cs
@@ -102,9 +102,8 @@ public static class PolygonHoleEditor
 
     private static LinearRing GetMostSimilarHole(IEnumerable<LinearRing> candidates, LinearRing hole)
     {
-        //here be dragons
-        //should probably compare size/position to get right hole
-        return candidates.First();
+        var distances = candidates.Select(c => (c.Centroid.Distance(hole.Centroid), c));
+        return distances.Count() > 0 ? distances.Min().Item2 : null;
     }
 
     private static List<NgisFeature> AddHole(HoleEditRequest edit)

--- a/DeltGeometriFelleskomponent.TopologyImplementation/PolygonHoleEditor.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/PolygonHoleEditor.cs
@@ -1,0 +1,138 @@
+﻿using DeltGeometriFelleskomponent.Models;
+using NetTopologySuite.Geometries;
+using static DeltGeometriFelleskomponent.TopologyImplementation.PolygonEditor;
+
+namespace DeltGeometriFelleskomponent.TopologyImplementation;
+
+public static class PolygonHoleEditor
+{
+    public static TopologyResponse EditHole(HoleEditRequest edit)
+    {
+        if (edit.Operation == EditOperation.Edit)
+        {
+            if (!edit.Index.HasValue)
+            {
+                throw new Exception("Missing index");
+            }
+
+            var feature = edit.Feature;
+            var polygon = (Polygon)feature.Geometry;
+
+            var oldRing = polygon.Holes[edit.Index.Value];
+            var newRing = edit.Ring;
+            var edits = CreateEditLineRequests(GetChangesToRing(oldRing, newRing), GetFeaturesReferencedByPolygon(feature, edit.AffectedFeatures), feature, oldRing);
+            if (edits.Count() > 1)
+            {
+                throw new Exception("Multiple edits found. Not supported!");
+            }
+            return LineEditor.EditLine(edits.First());
+
+        }
+        Func<HoleEditRequest, List<NgisFeature>> func = edit.Operation == EditOperation.Insert ? AddHole : RemoveHole;
+        return new TopologyResponse()
+        {
+            IsValid = true,
+            AffectedFeatures = func(edit).Concat(edit.AffectedFeatures != null ? edit.AffectedFeatures : new List<NgisFeature>()).ToList()
+        };
+    }
+
+    public static IEnumerable<HoleEditRequest> GetHoleEdits(EditPolygonRequest request)
+    {
+        var oldHoles = GetHoles((Polygon)request.Feature.Geometry);
+        var newHoles = GetHoles(request.EditedGeometry);
+
+        if (oldHoles.Count() == newHoles.Count())
+        {
+            var changedHoles = newHoles.Where(h => !oldHoles.Any(oh => oh.Equals(h)));
+            var edits = new List<HoleEditRequest>();
+            var holes = GetHoles((Polygon)request.Feature.Geometry);
+            foreach (var changedHole in changedHoles)
+            {
+                var oldHole = GetMostSimilarHole(oldHoles, changedHole);
+                oldHoles = oldHoles.Where(h => !h.Equals(oldHole)).ToArray();
+
+                edits.Add(new HoleEditRequest()
+                {
+                    Operation = EditOperation.Edit,
+                    Feature = request.Feature,
+                    AffectedFeatures = request.AffectedFeatures,
+                    Index = Array.FindIndex(holes, c => c.Equals(oldHole)),
+                    Ring = changedHole
+                });
+            }
+            return edits;
+
+        }
+        if (oldHoles.Count() < newHoles.Count())
+        {
+            return CoordinateHelper.GetRingsNotIn(oldHoles, newHoles).Select(hole => new HoleEditRequest()
+            {
+                Operation = EditOperation.Insert,
+                Ring = hole,
+                Feature = request.Feature,
+                AffectedFeatures = request.AffectedFeatures
+            }).ToList();
+
+        }
+        if (oldHoles.Count() > newHoles.Count())
+        {
+            return CoordinateHelper.GetRingsNotIn(newHoles, oldHoles).Select(hole => new HoleEditRequest()
+            {
+                Operation = EditOperation.Delete,
+                Ring = hole,
+                Feature = request.Feature,
+                AffectedFeatures = request.AffectedFeatures
+            }).ToList();
+        }
+
+        return new List<HoleEditRequest>();
+    }
+
+    private static LinearRing[] GetHoles(Polygon polygon)
+        => polygon.Holes ?? new LinearRing[] { };
+
+    private static LinearRing GetMostSimilarHole(LinearRing[] candidates, LinearRing hole)
+    {
+        return candidates[0];
+    }
+
+    private static List<NgisFeature> AddHole(HoleEditRequest edit)
+    {
+        var feature = edit.Feature;
+        var polygon = (Polygon)feature.Geometry;
+
+        var hole = PolygonCreator.CreateInteriorFeature(new LineString(edit.Ring.Coordinates));
+        var ring = new LinearRing(hole.Geometry.Coordinates);
+
+        var isReversed = ring.IsCCW;
+
+        var holes = polygon.Holes.ToList();
+        holes.Add(ring);
+
+        feature.Geometry = PolygonCreator.EnsureOrdering(new Polygon(polygon.Shell, holes.ToArray()));
+        var interiors = NgisFeatureHelper.GetInteriors(feature);
+        interiors.Add(new List<string>() { $"{(isReversed ? "-" : "")}{NgisFeatureHelper.GetLokalId(hole)}" });
+        NgisFeatureHelper.SetInterior(feature, interiors);
+        NgisFeatureHelper.SetOperation(feature, Operation.Replace);
+
+        return new List<NgisFeature>() { feature, hole };
+    }
+
+    private static List<NgisFeature> RemoveHole(HoleEditRequest edit)
+    {
+        var feature = edit.Feature;
+        var shell = ((Polygon)feature.Geometry).Shell;
+        var holes = ((Polygon)feature.Geometry).Holes.Where(h => !h.Equals(edit.Ring)).ToArray();
+        feature.Geometry = new Polygon(shell, holes);
+
+        NgisFeatureHelper.SetOperation(feature, Operation.Replace);
+
+        var ringFeature = edit.AffectedFeatures?.FirstOrDefault(f => f.Geometry.Equals(edit.Ring));
+        var ringFeatureId = ringFeature != null ? NgisFeatureHelper.GetLokalId(ringFeature) : null;
+        var interiors = NgisFeatureHelper.GetInteriors(feature);
+
+        NgisFeatureHelper.SetInterior(feature, ringFeatureId != null ? interiors.Where(h => !h.Select(NgisFeatureHelper.RemoveSign).Contains(ringFeatureId)).ToArray() : interiors);
+        return new List<NgisFeature>() { feature };
+    }
+
+}

--- a/DeltGeometriFelleskomponent.TopologyImplementation/TopologyImplementation.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/TopologyImplementation.cs
@@ -1,4 +1,5 @@
 ﻿using DeltGeometriFelleskomponent.Models;
+using DeltGeometriFelleskomponent.Models.Exceptions;
 using NetTopologySuite.Geometries;
 
 namespace DeltGeometriFelleskomponent.TopologyImplementation;
@@ -64,7 +65,7 @@ public class TopologyImplementation : ITopologyImplementation
         var referredFeatures = new List<NgisFeature>();
         if (feature.Geometry_Properties == null)
         {
-            throw new Exception("Missing Geometry_Properties on feature");
+            throw new BadRequestException("Missing Geometry_Properties on feature");
         }
 
         var holes = feature.Geometry_Properties?.Interiors?.SelectMany(i => i);
@@ -77,7 +78,7 @@ public class TopologyImplementation : ITopologyImplementation
             }
             else
             {
-                throw new Exception("Referred feature not present in AffectedFeatures");
+                throw new BadRequestException("Referred feature not present in AffectedFeatures");
             }
         }
 

--- a/DeltGeometriFelleskomponent.TopologyImplementation/TopologyImplementation.cs
+++ b/DeltGeometriFelleskomponent.TopologyImplementation/TopologyImplementation.cs
@@ -17,15 +17,17 @@ public class TopologyImplementation : ITopologyImplementation
                 IsValid = true
             },
             null => new TopologyResponse()
-
         };
 
     public IEnumerable<TopologyResponse> CreatePolygonsFromLines(CreatePolygonFromLinesRequest request)
         => _polygonCreator.CreatePolygonFromLines(request.Features, request.Centroids);
 
     public TopologyResponse EditLine(EditLineRequest request)
-        => GeometryEdit.EditLine(request); 
-    
+        => LineEditor.EditLine(request);
+
+    public TopologyResponse EditPolygon(EditPolygonRequest request)
+        => PolygonEditor.EditPolygon(request);
+
     private TopologyResponse HandlePolygon(CreateGeometryRequest request)
     {
         var result = new TopologyResponse()
@@ -39,8 +41,7 @@ public class TopologyImplementation : ITopologyImplementation
             if (request.Feature.Geometry_Properties?.Exterior == null) return new TopologyResponse();
             var referredFeatures = GetReferredFeatures(request.Feature, result.AffectedFeatures);
             // CreatePolygonFromLines now return NgisFeature FeatureReferences for lines
-            var res = _polygonCreator.CreatePolygonFromLines(referredFeatures, null);
-            //res.AffectedFeatures = result.AffectedFeatures.Concat(res.AffectedFeatures).ToList();
+            var res = _polygonCreator.CreatePolygonFromLines(referredFeatures, null);           
             return res.First();
         }
         return _polygonCreator.CreatePolygonFromGeometry(request);
@@ -82,4 +83,6 @@ public class TopologyImplementation : ITopologyImplementation
 
         return referredFeatures;
     }
+
+   
 }


### PR DESCRIPTION
fixes #36 

Støtter kun en enkelt endring 
(dvs 
- flytte en node
- slette en node
- sette inn en node
- slette et hull
- sette inn et hull)

Ikke testet i klient, men skrevet tester som dekker de fleste caser