### PR TITLE
[Sikkerhet] Oppdaterer med ny catalog-info.yaml og engelske filnavn

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/.sikkerhet/ @NilsIvarNes
+/.security/ @NilsIvarNes

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,4 +1,3 @@
-version: 3.0
 organization: Land
 product: NGIS
 repo_types: [Documentation]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,29 +10,3 @@ spec:
   lifecycle: "production"
   owner: "nasjonalt_geografisk_informasjonssystem_qms"
   system: "ngis"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Group"
-metadata:
-  name: "security_champion_NGIS-OpenAPI-felleskomponent-delt-geometri"
-  title: "Security Champion NGIS-OpenAPI-felleskomponent-delt-geometri"
-spec:
-  type: "security_champion"
-  parent: "land_security_champions"
-  members:
-  - "NilsIvarNes"
-  children:
-  - "resource:NGIS-OpenAPI-felleskomponent-delt-geometri"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Resource"
-metadata:
-  name: "NGIS-OpenAPI-felleskomponent-delt-geometri"
-  links:
-  - url: "https://github.com/kartverket/NGIS-OpenAPI-felleskomponent-delt-geometri"
-    title: "NGIS-OpenAPI-felleskomponent-delt-geometri på GitHub"
-spec:
-  type: "repo"
-  owner: "security_champion_NGIS-OpenAPI-felleskomponent-delt-geometri"
-  dependencyOf:
-  - "component:NGIS-OpenAPI-felleskomponent-delt-geometri"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage. Vi fjerner nå resource og sec. champ hierarkiet. Videre dropper vi å ha versionsnummer i description.yaml